### PR TITLE
Change cookie name to _ga

### DIFF
--- a/MeasurementProtocol.php
+++ b/MeasurementProtocol.php
@@ -29,7 +29,7 @@ class MeasurementProtocol extends BaseObject
     /** @var bool Use asynchronous requests (not waiting for a response) */
     public $asyncMode = false;
 
-    /** @var bool Try to set ClientId automatically from `ga_` cookie */
+    /** @var bool Try to set ClientId automatically from `_ga` cookie */
     public $autoSetClientId = false;
 
     /**
@@ -65,7 +65,7 @@ class MeasurementProtocol extends BaseObject
      */
     protected function extractClientIdFromCookie()
     {
-        $cookie = \Yii::$app->request->cookies->getValue('ga_', '');
+        $cookie = \Yii::$app->request->cookies->getValue('_ga', '');
         $cookieParts = explode('.', $cookie);
         $clientIdParts =  array_slice($cookieParts, -2);
         return implode('.', $clientIdParts);

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Versions in 1.* range are incompatible with PHP 7.2, use 2.* with Yii 2.0.13+ in
            'overrideIp' => false, // By default, IP is overridden by the user’s one, but you can disable this
            'anonymizeIp' => true, // If you want to anonymize the sender’s IP address
            'asyncMode' => true, // Enables the asynchronous mode (see below)
-           'autoSetClientId' => true, // Try to set ClientId automatically from the “ga_” cookie (disabled by default)
+           'autoSetClientId' => true, // Try to set ClientId automatically from the “_ga” cookie (disabled by default)
        ],
    ],
    ```
@@ -145,4 +145,17 @@ before sending the hit:
     ->setDocumentPath('/mypage')
     ->setAsyncRequest(true)
     ->sendPageview();
+```
+
+Auto set clientId from cookie
+-----------------------------
+If you set `autoSetClientId` to `true` durning component configuration you must disable `enableCookieValidation`.
+You can do this by configuring `request` component. Otherwise, the auto set clientId will not work.
+
+```php
+'components' => [
+    'request' => [
+        'enableCookieValidation' => false,
+    ],
+]
 ```


### PR DESCRIPTION
The default value for cookie name is `_ga` not `ga_`.

See:
* https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#cookieName
* https://github.com/fourlabsldn/GampBundle/blob/42d741c2c70baab42bf65bbb7888d152a83a1758/Service/AnalyticsFactory.php#L93
